### PR TITLE
Fix memory leak

### DIFF
--- a/src/pebble-faces.c
+++ b/src/pebble-faces.c
@@ -73,6 +73,7 @@ static void init(void) {
 }
 
 static void deinit(void) {
+  netimage_deinitialize(); // call this to avoid 20B memory leak
   window_destroy(window);
 }
 


### PR DESCRIPTION
Call netimage_deinitialize to fix 20B memory leak
